### PR TITLE
Add set_strings and get_strings tools for batch operations

### DIFF
--- a/provider/storage.yaml
+++ b/provider/storage.yaml
@@ -13,6 +13,8 @@ identity:
 tools:
   - tools/get_string.yaml
   - tools/set_string.yaml
+  - tools/get_strings.yaml
+  - tools/set_strings.yaml
   - tools/get_file.yaml
   - tools/set_file.yaml
   - tools/delete_key.yaml

--- a/tools/get_strings.py
+++ b/tools/get_strings.py
@@ -1,0 +1,21 @@
+from collections.abc import Generator
+from typing import Any
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+
+class GetStringsTool(Tool):
+    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
+        keys: list[str] = tool_parameters.get("keys", [])
+
+        if not isinstance(keys, list):
+            raise ValueError("keys must be a list of strings")
+
+        results = {}
+        for key in keys:
+            value = self.session.storage.get(key)
+            if value is not None:
+                results[key] = value.decode()
+
+        yield self.create_text_message(str(results))

--- a/tools/get_strings.yaml
+++ b/tools/get_strings.yaml
@@ -1,0 +1,28 @@
+identity:
+  name: get_strings
+  author: hjlarry
+  label:
+    en_US: get strings
+    zh_Hans: 获取多个字符串
+description:
+  human:
+    en_US: To get multiple key-value strings.
+    zh_Hans: 获取多个键值字符串。
+  llm: To get multiple key-value strings.
+parameters:
+  - name: keys
+    type: array
+    required: true
+    label:
+      en_US: Keys
+      zh_Hans: 键列表
+    human_description:
+      en_US: The list of keys whose values should be retrieved.
+      zh_Hans: 要获取的键列表。
+    llm_description: A list of keys to retrieve values for.
+    form: llm
+    items:
+      type: string
+extra:
+  python:
+    source: tools/get_strings.py

--- a/tools/set_strings.py
+++ b/tools/set_strings.py
@@ -1,0 +1,26 @@
+from collections.abc import Generator
+from typing import Any
+
+from dify_plugin import Tool
+from dify_plugin.entities.tool import ToolInvokeMessage
+
+
+class SetStringsTool(Tool):
+    def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
+        kv_pairs: list[dict[str, str]] = tool_parameters.get("items", [])
+
+        if not isinstance(kv_pairs, list):
+            raise ValueError("items must be a list of {key, value} objects")
+
+        for pair in kv_pairs:
+            key = pair.get("key")
+            value = pair.get("value")
+            if not key or value is None:
+                continue
+
+            if tool_parameters.get("size") and len(value) > tool_parameters["size"]:
+                raise ValueError(f"Value for key '{key}' is too large")
+
+            self.session.storage.set(key, value.encode())
+
+        yield self.create_text_message("SUCCESS: All strings set")

--- a/tools/set_strings.yaml
+++ b/tools/set_strings.yaml
@@ -1,0 +1,46 @@
+identity:
+  name: set_strings
+  author: hjlarry
+  label:
+    en_US: set strings
+    zh_Hans: 设置多个字符串
+description:
+  human:
+    en_US: To set multiple key-value strings.
+    zh_Hans: 设置多个键值字符串。
+  llm: To set multiple key-value strings.
+parameters:
+  - name: items
+    type: array
+    required: true
+    label:
+      en_US: Key-Value Pairs
+      zh_Hans: 键值对
+    human_description:
+      en_US: List of key-value pairs to set.
+      zh_Hans: 要设置的键值对列表。
+    llm_description: A list of objects with "key" and "value".
+    form: llm
+    items:
+      type: object
+      properties:
+        key:
+          type: string
+          required: true
+        value:
+          type: string
+          required: true
+  - name: size
+    type: number
+    required: false
+    label:
+      en_US: Size
+      zh_Hans: 大小
+    human_description:
+      en_US: Limit the size of each string.
+      zh_Hans: 限制每个字符串的大小。
+    llm_description: Maximum allowed string size.
+    form: form
+extra:
+  python:
+    source: tools/set_strings.py


### PR DESCRIPTION
Description:
This PR introduces two new tools:
set_strings: allows setting multiple key-value pairs in one call.
get_strings: allows fetching multiple keys at once and returns a dictionary of results.
Both tools extend the existing functionality while keeping the original single-string tools intact.

Changes:
New Python implementations (tools/set_strings.py, tools/get_strings.py).
New YAML definitions (tools/set_strings.yaml, tools/get_strings.yaml).
Validation for input arrays.
Size limit validation preserved.

Why:
This change improves efficiency and developer experience when handling multiple key-value pairs in one request.